### PR TITLE
Kotlin 2.2.0にアップグレード

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 kotlin {
     js(IR) {
-        moduleName = "kmisskey-js"
+        compilerOptions.moduleName = "kmisskey-js"
         nodejs()
         browser()
         binaries.library()

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 kotlin {
     jvmToolchain(11)
 
-    jvm { withJava() }
+    jvm()
     js(IR) {
         nodejs()
         browser()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
 kotest = "5.9.1"
-kotlin = "2.0.20"
+kotlin = "2.2.0"
 
 [libraries]
 kmpcommon = "work.socialhub:kmpcommon:0.0.1-SNAPSHOT"
-khttpclient = "work.socialhub:khttpclient:0.0.3-SNAPSHOT"
+khttpclient = "work.socialhub:khttpclient:0.0.8"
 ktor-core = "io.ktor:ktor-client-core:2.3.12"
 datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.6.1"
 coroutines-core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0"

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 kotlin {
     jvmToolchain(11)
 
-    jvm { withJava() }
+    jvm()
     js(IR) {
         nodejs()
         browser()


### PR DESCRIPTION
## Summary
- khttpclient 0.0.8との互換性のためKotlinを2.0.20から2.2.0に更新
- khttpclientを0.0.3-SNAPSHOTから0.0.8に更新
- Kotlin 2.2.0のAPI変更に対応（`moduleName` → `compilerOptions.moduleName`）
- 非推奨の`withJava()`を削除

## Test plan
- [x] `./gradlew publishToMavenLocal` が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kotlin compiler to version 2.2.0
  * Updated HTTP client library to version 0.0.8
  * Refined build configuration for optimized module compilation and JVM target handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->