### PR TITLE
Fix: シリアライゼーション関連の修正+v11レスポンス対応

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/ReadAnnouncementRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/ReadAnnouncementRequest.kt
@@ -1,9 +1,11 @@
 package work.socialhub.kmisskey.api.request
 
+import kotlinx.serialization.Serializable
 import work.socialhub.kmisskey.api.model.TokenRequest
 import kotlin.js.JsExport
 
 @JsExport
+@Serializable
 class ReadAnnouncementRequest(
     val announcementId: String
 ) : TokenRequest()

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/antennas/AntennasListRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/antennas/AntennasListRequest.kt
@@ -1,7 +1,9 @@
 package work.socialhub.kmisskey.api.request.antennas
 
+import kotlinx.serialization.Serializable
 import work.socialhub.kmisskey.api.model.TokenRequest
 import kotlin.js.JsExport
 
 @JsExport
+@Serializable
 class AntennasListRequest : TokenRequest()

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/Emoji.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/Emoji.kt
@@ -17,7 +17,7 @@ open class Emoji {
 
     lateinit var name: String
     lateinit var url: String
-    lateinit var category: String
+    var category: String? = null
 
     var aliases: Array<String>? = null
 

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/Emojis.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/Emojis.kt
@@ -1,10 +1,11 @@
 package work.socialhub.kmisskey.entity
 
 import kotlinx.serialization.Serializable
+import work.socialhub.kmisskey.util.json.EmojisSerializer
 import kotlin.js.JsExport
 
 @JsExport
-@Serializable
+@Serializable(with = EmojisSerializer::class)
 open class Emojis {
     var list: Array<Emoji> = arrayOf()
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/user/User.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/user/User.kt
@@ -46,7 +46,7 @@ abstract class User {
 
     abstract var instance: Instance?
     abstract var emojis: Emojis?
-    abstract var onlineStatus: String
+    abstract var onlineStatus: String?
 
     abstract var badgeRoles: Array<BadgeRole>
     abstract var roles: Array<Role>

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/user/UserDetailedNotMe.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/user/UserDetailedNotMe.kt
@@ -50,8 +50,8 @@ open class UserDetailedNotMe : UserLite() {
 
     var publicReactions: Boolean = false
 
-    lateinit var followingVisibility: String
-    lateinit var followersVisibility: String
+    var followingVisibility: String? = null
+    var followersVisibility: String? = null
 
     var twoFactorEnabled: Boolean = false
     var usePasswordLessLogin: Boolean = false

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/user/UserLite.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/user/UserLite.kt
@@ -29,7 +29,7 @@ open class UserLite : User() {
 
     override var instance: Instance? = null
     override var emojis: Emojis? = null
-    override lateinit var onlineStatus: String
+    override var onlineStatus: String? = null
 
     override var badgeRoles: Array<BadgeRole> = arrayOf()
     override var roles: Array<Role> = arrayOf()

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/json/EmojisSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/json/EmojisSerializer.kt
@@ -1,0 +1,75 @@
+package work.socialhub.kmisskey.util.json
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ArraySerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import work.socialhub.kmisskey.entity.Emoji
+import work.socialhub.kmisskey.entity.Emojis
+
+/**
+ * Emojis のカスタムシリアライザー
+ * v11系: 配列形式 [{"name":"misskey","url":"..."}]
+ * v12系以降: オブジェクト形式（空のオブジェクト {} など）
+ */
+@OptIn(ExperimentalSerializationApi::class)
+object EmojisSerializer : KSerializer<Emojis> {
+
+    private val emojiArraySerializer = ArraySerializer(Emoji.serializer())
+
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("Emojis")
+
+    override fun deserialize(decoder: Decoder): Emojis {
+        val jsonDecoder = decoder as JsonDecoder
+        val element = jsonDecoder.decodeJsonElement()
+
+        val emojis = Emojis()
+
+        when (element) {
+            // v11系: 配列形式
+            is JsonArray -> {
+                emojis.list = jsonDecoder.json.decodeFromJsonElement(
+                    emojiArraySerializer,
+                    element
+                )
+            }
+            // v12系以降: オブジェクト形式（空のオブジェクトまたはlistを含む）
+            is JsonObject -> {
+                val listElement = element["list"]
+                if (listElement != null && listElement is JsonArray) {
+                    emojis.list = jsonDecoder.json.decodeFromJsonElement(
+                        emojiArraySerializer,
+                        listElement.jsonArray
+                    )
+                }
+                // listがない場合は空の配列のまま
+            }
+            else -> {
+                // その他の場合は空の配列のまま
+            }
+        }
+
+        return emojis
+    }
+
+    override fun serialize(encoder: Encoder, value: Emojis) {
+        // シリアライズ時はオブジェクト形式で出力
+        val jsonEncoder = encoder as JsonEncoder
+        val jsonObject = kotlinx.serialization.json.buildJsonObject {
+            put("list", jsonEncoder.json.encodeToJsonElement(
+                emojiArraySerializer,
+                value.list
+            ))
+        }
+        jsonEncoder.encodeJsonElement(jsonObject)
+    }
+}

--- a/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/EmojisSerializerTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/EmojisSerializerTest.kt
@@ -1,0 +1,65 @@
+package work.socialhub.kmisskey.unit
+
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import work.socialhub.kmisskey.entity.Emojis
+
+/**
+ * EmojisSerializer のユニットテスト
+ */
+class EmojisSerializerTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    @Test
+    fun testDeserializeArrayFormat() {
+        // v11系: 配列形式
+        val jsonString = """[{"name":"misskey","url":"https://example.com/emoji.png","category":"default","aliases":[]}]"""
+        val emojis = json.decodeFromString<Emojis>(jsonString)
+
+        assertEquals(1, emojis.list.size)
+        assertEquals("misskey", emojis.list[0].name)
+        assertEquals("https://example.com/emoji.png", emojis.list[0].url)
+    }
+
+    @Test
+    fun testDeserializeEmptyArray() {
+        // 空の配列
+        val jsonString = """[]"""
+        val emojis = json.decodeFromString<Emojis>(jsonString)
+
+        assertEquals(0, emojis.list.size)
+    }
+
+    @Test
+    fun testDeserializeObjectFormat() {
+        // オブジェクト形式（listフィールドあり）
+        val jsonString = """{"list":[{"name":"test","url":"https://example.com/test.png","category":"test","aliases":[]}]}"""
+        val emojis = json.decodeFromString<Emojis>(jsonString)
+
+        assertEquals(1, emojis.list.size)
+        assertEquals("test", emojis.list[0].name)
+    }
+
+    @Test
+    fun testDeserializeEmptyObject() {
+        // 空のオブジェクト（v12系以降で使われる場合）
+        val jsonString = """{}"""
+        val emojis = json.decodeFromString<Emojis>(jsonString)
+
+        assertEquals(0, emojis.list.size)
+    }
+
+    @Test
+    fun testSerialize() {
+        val emojis = Emojis()
+        val serialized = json.encodeToString(Emojis.serializer(), emojis)
+
+        // シリアライズ後もデシリアライズできることを確認
+        val deserialized = json.decodeFromString<Emojis>(serialized)
+        assertEquals(emojis.list.size, deserialized.list.size)
+    }
+}

--- a/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/EmojisSerializerTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/EmojisSerializerTest.kt
@@ -2,8 +2,10 @@ package work.socialhub.kmisskey.unit
 
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import work.socialhub.kmisskey.entity.Emojis
+import work.socialhub.kmisskey.entity.user.User
 
 /**
  * EmojisSerializer のユニットテスト
@@ -61,5 +63,70 @@ class EmojisSerializerTest {
         // シリアライズ後もデシリアライズできることを確認
         val deserialized = json.decodeFromString<Emojis>(serialized)
         assertEquals(emojis.list.size, deserialized.list.size)
+    }
+
+    @Test
+    fun testDeserializeV11UserWithEmojisArray() {
+        // v11系サーバーからの実際のAPIレスポンス (users.show)
+        val jsonString = """
+        {
+          "id": "9gzj6yo2l4",
+          "name": "たけうちひろあき（:misskey:.dev）",
+          "username": "takke",
+          "host": null,
+          "avatarUrl": "https://media.misskey.dev/dev/thumbnail-f723decf-e534-4283-8f1c-7e99e524f867.jpg",
+          "avatarBlurhash": "yEDcR2V?00o#~UjER",
+          "avatarColor": null,
+          "isAdmin": false,
+          "isBot": false,
+          "isCat": false,
+          "emojis": [
+            {
+              "name": "misskey",
+              "url": "https://raw.githubusercontent.com/tkmrgit/misskey-emoji/c8a1b6ac5442de4b29abeb2fa021bb8a0979818a/emoji/00eb7798-a784-43e9-b4ea-62c995fef999%5B1%5D.png"
+            }
+          ],
+          "url": null,
+          "createdAt": "2023-07-09T21:49:07.970Z",
+          "updatedAt": "2023-12-03T06:10:47.245Z",
+          "bannerUrl": null,
+          "bannerColor": null,
+          "isLocked": false,
+          "isModerator": false,
+          "isSilenced": false,
+          "isSuspended": false,
+          "description": "ZonePane(ぞーぺん)の作者です。",
+          "location": null,
+          "birthday": null,
+          "fields": [],
+          "followersCount": 16,
+          "followingCount": 4,
+          "notesCount": 54,
+          "pinnedNoteIds": [],
+          "pinnedNotes": [],
+          "pinnedPageId": null,
+          "pinnedPage": null,
+          "twoFactorEnabled": false,
+          "usePasswordLessLogin": false,
+          "securityKeys": false,
+          "twitter": null,
+          "github": null,
+          "discord": null,
+          "movedToUserId": null,
+          "movedToUser": null
+        }
+        """.trimIndent()
+
+        val user = json.decodeFromString<User>(jsonString)
+
+        assertEquals("9gzj6yo2l4", user.id)
+        assertEquals("takke", user.username)
+        assertNotNull(user.emojis)
+        assertEquals(1, user.emojis!!.list.size)
+        assertEquals("misskey", user.emojis!!.list[0].name)
+        assertEquals(
+            "https://raw.githubusercontent.com/tkmrgit/misskey-emoji/c8a1b6ac5442de4b29abeb2fa021bb8a0979818a/emoji/00eb7798-a784-43e9-b4ea-62c995fef999%5B1%5D.png",
+            user.emojis!!.list[0].url
+        )
     }
 }


### PR DESCRIPTION
ZonePaneに導入するために必要だったいくつかの修正の1つです。
(Emojisは他にも必要だった気がしますが現状ここまでは必要なのでPR出しておきます)
よろしくお願いいたします。

## Summary
- Emojis用のカスタムシリアライザーを追加し、ユニットテストを実装
- AntennasListRequest に @Serializable アノテーションを追加
- ReadAnnouncementRequest に @Serializable アノテーションを追加
- Misskey v11のレスポンス形式に対応 <- 別PRにしようと思っていましたが本PRに依存するのでこちらでお願いします

## Test plan
- [ ] 既存のユニットテストが通ることを確認
- [ ] アンテナ一覧取得が正常に動作することを確認
- [ ] お知らせ既読処理が正常に動作することを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced serialization capabilities for API requests and emoji data with backward-compatible support for different data formats, ensuring reliable data handling.

* **Tests**
  * Added comprehensive unit tests for emoji serialization and deserialization scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->