### PR TITLE
Fix: レスポンスステータスコード処理を2xx範囲対応に改善

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/internal/Internal.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/internal/Internal.kt
@@ -38,7 +38,7 @@ object Internal {
     ): EmptyResponse {
         try {
             val response = function()
-            if (response.status == 200) {
+            if (response.status in 200..299) {
                 return EmptyResponse()
             }
 
@@ -54,7 +54,7 @@ object Internal {
     ): Response<T> {
         try {
             val response = function()
-            if (response.status == 200) {
+            if (response.status in 200..299) {
                 return Response(
                     response.typedBody(json),
                     response.stringBody,


### PR DESCRIPTION
204(本文なしの結果)が返ってきたときに失敗しないようにしました。

## Summary
- レスポンスステータスコードを2xx範囲で正常判定するよう改善

## Test plan
- [ ] 各種APIリクエストが正常に動作することを確認
- [ ] 200以外の2xxステータス（201, 204等）が正常に処理されることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API response handling to recognize a broader range of successful HTTP responses, not just standard 200 status codes. This enhances compatibility and reliability when communicating with servers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->