### PR TITLE
Fix: 認証URLプロトコル取得の修正

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/internal/api/AuthResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/internal/api/AuthResourceImpl.kt
@@ -41,7 +41,7 @@ class AuthResourceImpl(
         request: GetMiAuthUriRequest
     ): Response<String> {
         val url = Url(uri)
-        var authUrl = "${url.protocol}://${url.host}/miauth/${request.sessionId}"
+        var authUrl = "${url.protocol.name}://${url.host}/miauth/${request.sessionId}"
 
         val m = mutableListOf<String>()
         request.name?.let { m += "name=${e(it)}" }


### PR DESCRIPTION
## Summary
- AuthResourceImpl でのURLプロトコル取得処理を修正

## Test plan
- [ ] MiAuth の認証フローが正常に動作することを確認
