### PR TITLE
Fix/reaction emojis map format

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/json/EmojisSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/json/EmojisSerializer.kt
@@ -11,6 +11,8 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import work.socialhub.kmisskey.entity.Emoji
 import work.socialhub.kmisskey.entity.Emojis
@@ -19,6 +21,7 @@ import work.socialhub.kmisskey.entity.Emojis
  * Emojis のカスタムシリアライザー
  * v11系: 配列形式 [{"name":"misskey","url":"..."}]
  * v12系以降: オブジェクト形式（空のオブジェクト {} など）
+ * reactionEmojis: マップ形式 {"name@host":"url", ...}
  */
 @OptIn(ExperimentalSerializationApi::class)
 object EmojisSerializer : KSerializer<Emojis> {
@@ -50,8 +53,23 @@ object EmojisSerializer : KSerializer<Emojis> {
                         emojiArraySerializer,
                         listElement.jsonArray
                     )
+                } else if (element.isNotEmpty()) {
+                    // マップ形式: {"name@host": "url", ...}
+                    // reactionEmojis用のパース処理
+                    val emojiList = element.entries.mapNotNull { (key, value) ->
+                        val url = (value as? JsonPrimitive)?.contentOrNull
+                        if (url != null) {
+                            Emoji().apply {
+                                this.name = key  // "igyo@fedibird.com" 全体をnameに設定
+                                this.url = url
+                            }
+                        } else {
+                            null
+                        }
+                    }
+                    emojis.list = emojiList.toTypedArray()
                 }
-                // listがない場合は空の配列のまま
+                // それ以外（空のオブジェクト）は空の配列のまま
             }
             else -> {
                 // その他の場合は空の配列のまま

--- a/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/EmojisSerializerTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/EmojisSerializerTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import work.socialhub.kmisskey.entity.Emojis
+import work.socialhub.kmisskey.entity.Note
 import work.socialhub.kmisskey.entity.user.User
 
 /**
@@ -128,5 +129,78 @@ class EmojisSerializerTest {
             "https://raw.githubusercontent.com/tkmrgit/misskey-emoji/c8a1b6ac5442de4b29abeb2fa021bb8a0979818a/emoji/00eb7798-a784-43e9-b4ea-62c995fef999%5B1%5D.png",
             user.emojis!!.list[0].url
         )
+    }
+
+    @Test
+    fun testDeserializeMapFormat() {
+        // reactionEmojis用: マップ形式 {"name@host": "url", ...}
+        val jsonString = """{"zonepane@fedibird.com":"https://s3.fedibird.com/custom_emojis/images/000/331/764/original/73113cfb7278b3b7.png"}"""
+        val emojis = json.decodeFromString<Emojis>(jsonString)
+
+        assertEquals(1, emojis.list.size)
+        assertEquals("zonepane@fedibird.com", emojis.list[0].name)
+        assertEquals(
+            "https://s3.fedibird.com/custom_emojis/images/000/331/764/original/73113cfb7278b3b7.png",
+            emojis.list[0].url
+        )
+    }
+
+    @Test
+    fun testDeserializeNoteWithReactionEmojis() {
+        // reactionEmojis を含む Note のテスト
+        val jsonString = """
+        {
+          "id": "aft56qpbmtv30g52",
+          "createdAt": "2025-12-03T05:40:07.727Z",
+          "userId": "9bt8uw4ttx",
+          "user": {
+            "id": "9bt8uw4ttx",
+            "name": "たけうちひろあき:io:🐧",
+            "username": "takke",
+            "host": null,
+            "avatarUrl": "https://example.com/avatar.webp",
+            "isBot": false,
+            "isCat": false,
+            "emojis": {},
+            "onlineStatus": "online"
+          },
+          "text": "絵文字リアクションのテスト",
+          "cw": null,
+          "visibility": "public",
+          "localOnly": false,
+          "reactionAcceptance": "nonSensitiveOnly",
+          "renoteCount": 0,
+          "repliesCount": 0,
+          "reactionCount": 1,
+          "reactions": {
+            ":zonepane@fedibird.com:": 1
+          },
+          "reactionEmojis": {
+            "zonepane@fedibird.com": "https://s3.fedibird.com/custom_emojis/images/000/331/764/original/73113cfb7278b3b7.png"
+          },
+          "fileIds": [],
+          "files": [],
+          "replyId": null,
+          "renoteId": null,
+          "clippedCount": 0
+        }
+        """.trimIndent()
+        val note = json.decodeFromString<Note>(jsonString)
+
+        assertEquals("aft56qpbmtv30g52", note.id)
+        assertEquals("絵文字リアクションのテスト", note.text)
+
+        // reactionEmojis の検証
+        assertNotNull(note.reactionEmojis)
+        assertEquals(1, note.reactionEmojis!!.list.size)
+        assertEquals("zonepane@fedibird.com", note.reactionEmojis!!.list[0].name)
+        assertEquals(
+            "https://s3.fedibird.com/custom_emojis/images/000/331/764/original/73113cfb7278b3b7.png",
+            note.reactionEmojis!!.list[0].url
+        )
+
+        // user.emojis（空オブジェクト形式）の検証
+        assertNotNull(note.user.emojis)
+        assertEquals(0, note.user.emojis!!.list.size)
     }
 }


### PR DESCRIPTION
`Note.reactionEmojis` のパースに対応しました

## Summary
- EmojisSerializer で reactionEmojis のマップ形式 `{"name@host": "url"}` のパースに対応
- 他サーバーからのリアクション絵文字が正しく取得できるように修正

## Background
Misskey API の `Note.reactionEmojis` は `{"igyo@fedibird.com": "https://..."}` のようなマップ形式で返されるが、従来の EmojisSerializer は配列形式とオブジェクト形式（listキー付き）のみ対応していた。

## Test plan
- [ ] リモートサーバーからのリアクション絵文字が正しく取得できることを確認
- [ ] 既存の配列形式・オブジェクト形式のパースが引き続き動作することを確認

※ZonePaneでいずれも確認済みです

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji handling to support additional reaction emoji data formats, ensuring compatibility with various data representations.

* **Tests**
  * Expanded test coverage for emoji deserialization across different data formats, including reaction emoji handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->