### PR TITLE
Fix: ap/show APIのobjectフィールドをオブジェクトとしてパース

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/response/ApShowResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/response/ApShowResponse.kt
@@ -1,15 +1,16 @@
 package work.socialhub.kmisskey.api.response
 
-import kotlinx.serialization.Serializable
 import work.socialhub.kmisskey.entity.Note
 import work.socialhub.kmisskey.entity.user.User
 import kotlin.js.JsExport
 
+/**
+ * ap/show APIのレスポンス
+ * object フィールドはオブジェクトとして返されるため、ApResourceImpl で手動パースする
+ */
 @JsExport
-@Serializable
 class ApShowResponse {
     var type: String? = null
     var note: Note? = null
     var user: User? = null
-    var `object`: String? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/internal/api/ApResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/internal/api/ApResourceImpl.kt
@@ -1,11 +1,20 @@
 package work.socialhub.kmisskey.internal.api
 
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import work.socialhub.khttpclient.HttpRequest
 import work.socialhub.kmisskey.MisskeyAPI.ApShow
 import work.socialhub.kmisskey.api.ApResource
 import work.socialhub.kmisskey.api.request.ApShowRequest
 import work.socialhub.kmisskey.api.response.ApShowResponse
+import work.socialhub.kmisskey.entity.Note
 import work.socialhub.kmisskey.entity.share.Response
-import work.socialhub.kmisskey.internal.Internal.fromJson
+import work.socialhub.kmisskey.entity.user.User
+import work.socialhub.kmisskey.internal.Internal.json
+import work.socialhub.kmisskey.internal.Internal.toJson
+import work.socialhub.kmisskey.internal.util.MediaType
+import work.socialhub.kmpcommon.runBlocking
 
 class ApResourceImpl(
     uri: String,
@@ -20,25 +29,38 @@ class ApResourceImpl(
         request: ApShowRequest
     ): Response<ApShowResponse> {
 
-        // user または note に対応するためここでリクエストしてパース
-        val response: Response<ApShowResponse> = post(
-            ApShow.path, request
-        )
+        // ApShowResponse は object フィールドがオブジェクトとして返されるため手動でパース
+        return runBlocking {
+            val httpResponse = HttpRequest()
+                .url(uri + ApShow.path)
+                .json(toJson(auth(request)))
+                .accept(MediaType.JSON)
+                .post()
 
-        val apShowResponse = response.data
-        if ("Note" == apShowResponse.type) {
-            // object -> Note
-            apShowResponse.note = fromJson(
-                apShowResponse.`object`!!
-            )
+            val responseJson = httpResponse.stringBody
+            val jsonObject = json.parseToJsonElement(responseJson).jsonObject
 
-        } else if ("User" == apShowResponse.type) {
-            // object -> User
-            apShowResponse.user = fromJson(
-                apShowResponse.`object`!!
-            )
+            val apShowResponse = ApShowResponse()
+            apShowResponse.type = jsonObject["type"]?.jsonPrimitive?.content
+
+            // object フィールドがオブジェクトの場合、type に応じて note または user に変換
+            val objectElement = jsonObject["object"]
+            if (objectElement != null && objectElement is JsonObject) {
+                when (apShowResponse.type) {
+                    "Note" -> {
+                        apShowResponse.note = json.decodeFromJsonElement(
+                            Note.serializer(), objectElement
+                        )
+                    }
+                    "User" -> {
+                        apShowResponse.user = json.decodeFromJsonElement(
+                            User.serializer(), objectElement
+                        )
+                    }
+                }
+            }
+
+            Response(apShowResponse, responseJson)
         }
-
-        return response
     }
 }


### PR DESCRIPTION
- ap/show APIが返す `object` フィールドがパースできないので修正しました
- `ApShowResponse` から `object` フィールドを削除し、`ApResourceImpl` でJSONを直接パースして `note` または `user` に変換

## 修正内容
- `ApShowResponse.kt`: `object: String?` フィールドを削除、`@Serializable` を削除
- `ApResourceImpl.kt`: 生JSONを手動でパースし、`type` に応じて `Note` または `User` にデシリアライズ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of ActivityPub resource responses and serialization behavior.

* **Refactor**
  * Updated internal API response processing logic for better reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->