### PR TITLE
Fix: Choice.voted プロパティに @SerialName アノテーションを追加

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/Choice.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/Choice.kt
@@ -1,5 +1,6 @@
 package work.socialhub.kmisskey.entity
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 
@@ -9,6 +10,8 @@ open class Choice {
 
     var text: String? = null
     var votes: Int? = null
+
+    @SerialName("isVoted")
     var voted = false
 }
 


### PR DESCRIPTION
## Summary
- `Choice` クラスの `voted` プロパティに `@SerialName("isVoted")` アノテーションを追加
- Misskey API のレスポンスでは `isVoted` というフィールド名で返されるため、正しくデシリアライズされるように修正

## 修正内容
- `Choice.kt`: `voted` プロパティに `@SerialName("isVoted")` アノテーションを追加

## Test plan
- [ ] 投票付きノートの取得時に `isVoted` が正しくパースされることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed serialization handling for poll choice voting status to ensure proper compatibility with data responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->