### PR TITLE
Fix: ColorDecoder の # プレフィックスなし16進数カラーコードサポート

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/ColorDecoder.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/ColorDecoder.kt
@@ -9,9 +9,9 @@ object ColorDecoder {
      */
     fun decode(color: String): Color {
 
-        // #RRGGBB
-        if (color.startsWith("#")) {
-            val hex = color.replace("#", "")
+        // #RRGGBB または RRGGBB (6文字の16進数)
+        if (color.startsWith("#") || (color.length == 6 && color.all { it.isHexDigit() })) {
+            val hex = color.removePrefix("#")
             val r = hex.substring(0, 2).toInt(16)
             val g = hex.substring(2, 4).toInt(16)
             val b = hex.substring(4, 6).toInt(16)
@@ -47,5 +47,12 @@ object ColorDecoder {
             this.g = g
             this.b = b
         }
+    }
+
+    /**
+     * 文字が16進数の文字かどうかを判定する
+     */
+    private fun Char.isHexDigit(): Boolean {
+        return this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
     }
 }


### PR DESCRIPTION
## Summary
- `ColorDecoder` が `#` プレフィックスなしの16進数カラーコード（例: `86b300`）をサポートするように修正

## Background
一部のMisskeyインスタンス（例: misskey.04.si）では、Roleのカラー情報が `#RRGGBB` 形式ではなく `RRGGBB` 形式で返されることがあり、`NumberFormatException` が発生していました。

## Changes
- `ColorDecoder.decode()` に6文字の16進数文字列を検出するロジックを追加
- 16進数判定用のヘルパー関数 `isHexDigit()` を追加

## Test plan
- [ ] `#RRGGBB` 形式のカラーコードが正しくパースされることを確認
- [ ] `RRGGBB` 形式のカラーコードが正しくパースされることを確認
- [ ] misskey.04.si などのサーバーでアカウント情報が取得できることを確認
  - いわゆるりんごぱいなどのサーバーでアカウント情報が取得できないためこの不具合を見つけましたので。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Color input now accepts hexadecimal format without the # symbol in addition to standard prefixed format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->