### PR TITLE
Add tests for ColorDecoder hex parsing

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/ColorDecoder.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/ColorDecoder.kt
@@ -9,9 +9,9 @@ object ColorDecoder {
      */
     fun decode(color: String): Color {
 
-        // #RRGGBB
-        if (color.startsWith("#")) {
-            val hex = color.replace("#", "")
+        // #RRGGBB または RRGGBB (6文字の16進数)
+        if (color.startsWith("#") || (color.length == 6 && color.all { it.isHexDigit() })) {
+            val hex = color.removePrefix("#")
             val r = hex.substring(0, 2).toInt(16)
             val g = hex.substring(2, 4).toInt(16)
             val b = hex.substring(4, 6).toInt(16)
@@ -47,5 +47,12 @@ object ColorDecoder {
             this.g = g
             this.b = b
         }
+    }
+
+    /**
+     * 文字が16進数の文字かどうかを判定する
+     */
+    private fun Char.isHexDigit(): Boolean {
+        return this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
     }
 }

--- a/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/ColorDecoderTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/ColorDecoderTest.kt
@@ -1,0 +1,26 @@
+package work.socialhub.kmisskey.unit
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import work.socialhub.kmisskey.util.ColorDecoder
+
+class ColorDecoderTest {
+
+    @Test
+    fun decodeHexWithPrefix() {
+        val color = ColorDecoder.decode("#86b300")
+
+        assertEquals(0x86, color.r)
+        assertEquals(0xb3, color.g)
+        assertEquals(0x00, color.b)
+    }
+
+    @Test
+    fun decodeHexWithoutPrefix() {
+        val color = ColorDecoder.decode("86b300")
+
+        assertEquals(0x86, color.r)
+        assertEquals(0xb3, color.g)
+        assertEquals(0x00, color.b)
+    }
+}


### PR DESCRIPTION
## Summary
- Allow `ColorDecoder` to decode 6-digit hexadecimal color strings without the `#` prefix
- Add a helper for hexadecimal digit detection and reuse it when parsing
- Add unit tests for parsing hex values with and without a leading `#`

## Testing
- `./gradlew :core:jvmTest --tests "work.socialhub.kmisskey.unit.ColorDecoderTest"`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940d32d4ad8832ab5e04d0a262aaec5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Color decoding now supports hex colors with or without the # prefix (e.g., #FF0000 and FF0000). Existing rgb() and comma-separated formats remain supported.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->