### PR TITLE
Fix: mutedWords/hardMutedWords の正規表現パターンに対応

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/MutedWordItem.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/MutedWordItem.kt
@@ -1,0 +1,28 @@
+package work.socialhub.kmisskey.entity
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kmisskey.util.json.MutedWordItemSerializer
+import kotlin.js.JsExport
+
+/**
+ * ミュートワード設定の項目
+ * Misskey の mutedWords/hardMutedWords は以下の2種類の形式を混在できる:
+ * - 正規表現パターン: "/pattern/" 形式の文字列
+ * - キーワード配列: ["word1", "word2"] 形式のAND条件
+ */
+@JsExport
+@Serializable(with = MutedWordItemSerializer::class)
+sealed class MutedWordItem {
+
+    /**
+     * 正規表現パターン
+     * 例: "/(@.+@.+\\.+){5,}/"
+     */
+    data class RegexPattern(val pattern: String) : MutedWordItem()
+
+    /**
+     * キーワード配列（AND条件）
+     * 例: ["word1", "word2"] → word1 AND word2 の両方を含む場合にミュート
+     */
+    data class Keywords(val words: List<String>) : MutedWordItem()
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/user/MeDetailed.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/user/MeDetailed.kt
@@ -2,6 +2,7 @@ package work.socialhub.kmisskey.entity.user
 
 import kotlinx.serialization.Serializable
 import work.socialhub.kmisskey.entity.Achievement
+import work.socialhub.kmisskey.entity.MutedWordItem
 import kotlin.js.JsExport
 
 @JsExport
@@ -42,8 +43,8 @@ class MeDetailed : UserDetailedNotMe() {
     var hasPendingReceivedFollowRequest: Boolean = false
     var unreadNotificationsCount: Int = 0
 
-    var mutedWords: Array<Array<String>> = arrayOf()
-    var hardMutedWords: Array<Array<String>> = arrayOf()
+    var mutedWords: List<MutedWordItem> = listOf()
+    var hardMutedWords: List<MutedWordItem> = listOf()
     var mutedInstances: Array<String> = arrayOf()
 
     // TODO: Object

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/json/MutedWordItemSerializer.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/json/MutedWordItemSerializer.kt
@@ -1,0 +1,72 @@
+package work.socialhub.kmisskey.util.json
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.contentOrNull
+import work.socialhub.kmisskey.entity.MutedWordItem
+
+/**
+ * MutedWordItem のカスタムシリアライザー
+ * Misskey の mutedWords/hardMutedWords は以下の2種類の形式を混在できる:
+ * - 正規表現パターン: "/pattern/" 形式の文字列
+ * - キーワード配列: ["word1", "word2"] 形式のAND条件
+ */
+object MutedWordItemSerializer : KSerializer<MutedWordItem> {
+
+    override val descriptor: SerialDescriptor =
+        buildClassSerialDescriptor("MutedWordItem")
+
+    override fun deserialize(decoder: Decoder): MutedWordItem {
+        val jsonDecoder = decoder as JsonDecoder
+        val element = jsonDecoder.decodeJsonElement()
+
+        return when (element) {
+            // 文字列の場合: 正規表現パターン
+            is JsonPrimitive -> {
+                val content = element.contentOrNull
+                    ?: throw IllegalStateException("MutedWordItem: content is null: $element")
+                MutedWordItem.RegexPattern(content)
+            }
+            // 配列の場合: キーワード配列（AND条件）
+            is JsonArray -> {
+                val words = element.mapNotNull { item ->
+                    (item as? JsonPrimitive)?.contentOrNull
+                }
+                MutedWordItem.Keywords(words)
+            }
+
+            else -> {
+                throw IllegalStateException("MutedWordItem: unknown format: $element")
+            }
+        }
+    }
+
+    override fun serialize(encoder: Encoder, value: MutedWordItem) {
+        val jsonEncoder = encoder as JsonEncoder
+
+        when (value) {
+            is MutedWordItem.RegexPattern -> {
+                jsonEncoder.encodeJsonElement(JsonPrimitive(value.pattern))
+            }
+
+            is MutedWordItem.Keywords -> {
+                val jsonArray = buildJsonArray {
+                    value.words.forEach { word ->
+                        add(JsonPrimitive(word))
+                    }
+                }
+                jsonEncoder.encodeJsonElement(jsonArray)
+            }
+        }
+    }
+}

--- a/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/MutedWordItemSerializerTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/MutedWordItemSerializerTest.kt
@@ -1,0 +1,140 @@
+package work.socialhub.kmisskey.unit
+
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import work.socialhub.kmisskey.entity.MutedWordItem
+
+/**
+ * MutedWordItemSerializer のユニットテスト
+ */
+class MutedWordItemSerializerTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    private val listSerializer = ListSerializer(MutedWordItem.serializer())
+
+    @Test
+    fun testDeserializeRegexPattern() {
+        // 正規表現パターン（文字列）
+        val jsonString = """"/(@.+@.+\\\\..+){5,}/""""
+        val item = json.decodeFromString<MutedWordItem>(jsonString)
+
+        assertTrue(item is MutedWordItem.RegexPattern)
+        assertEquals("/(@.+@.+\\\\..+){5,}/", (item as MutedWordItem.RegexPattern).pattern)
+    }
+
+    @Test
+    fun testDeserializeKeywords() {
+        // キーワード配列（AND条件）
+        val jsonString = """["word1", "word2"]"""
+        val item = json.decodeFromString<MutedWordItem>(jsonString)
+
+        assertTrue(item is MutedWordItem.Keywords)
+        val keywords = item as MutedWordItem.Keywords
+        assertEquals(2, keywords.words.size)
+        assertEquals("word1", keywords.words[0])
+        assertEquals("word2", keywords.words[1])
+    }
+
+    @Test
+    fun testDeserializeEmptyKeywords() {
+        // 空のキーワード配列
+        val jsonString = """[]"""
+        val item = json.decodeFromString<MutedWordItem>(jsonString)
+
+        assertTrue(item is MutedWordItem.Keywords)
+        assertEquals(0, (item as MutedWordItem.Keywords).words.size)
+    }
+
+    @Test
+    fun testDeserializeMixedList() {
+        // 正規表現とキーワードの混在リスト
+        val jsonString = """["/pattern/", ["keyword1", "keyword2"], "/another/"]"""
+        val items = json.decodeFromString(listSerializer, jsonString)
+
+        assertEquals(3, items.size)
+
+        // 1番目: 正規表現
+        assertTrue(items[0] is MutedWordItem.RegexPattern)
+        assertEquals("/pattern/", (items[0] as MutedWordItem.RegexPattern).pattern)
+
+        // 2番目: キーワード配列
+        assertTrue(items[1] is MutedWordItem.Keywords)
+        val keywords = items[1] as MutedWordItem.Keywords
+        assertEquals(2, keywords.words.size)
+        assertEquals("keyword1", keywords.words[0])
+        assertEquals("keyword2", keywords.words[1])
+
+        // 3番目: 正規表現
+        assertTrue(items[2] is MutedWordItem.RegexPattern)
+        assertEquals("/another/", (items[2] as MutedWordItem.RegexPattern).pattern)
+    }
+
+    @Test
+    fun testSerializeRegexPattern() {
+        val item = MutedWordItem.RegexPattern("/test/")
+        val serialized = json.encodeToString(MutedWordItem.serializer(), item)
+
+        assertEquals("\"/test/\"", serialized)
+    }
+
+    @Test
+    fun testSerializeKeywords() {
+        val item = MutedWordItem.Keywords(listOf("word1", "word2"))
+        val serialized = json.encodeToString(MutedWordItem.serializer(), item)
+
+        assertEquals("""["word1","word2"]""", serialized)
+    }
+
+    @Test
+    fun testSerializeAndDeserializeRoundTrip() {
+        val original = listOf(
+            MutedWordItem.RegexPattern("/pattern/"),
+            MutedWordItem.Keywords(listOf("a", "b")),
+        )
+
+        val serialized = json.encodeToString(listSerializer, original)
+        val deserialized = json.decodeFromString(listSerializer, serialized)
+
+        assertEquals(original.size, deserialized.size)
+
+        assertTrue(deserialized[0] is MutedWordItem.RegexPattern)
+        assertEquals("/pattern/", (deserialized[0] as MutedWordItem.RegexPattern).pattern)
+
+        assertTrue(deserialized[1] is MutedWordItem.Keywords)
+        assertEquals(listOf("a", "b"), (deserialized[1] as MutedWordItem.Keywords).words)
+    }
+
+    @Test
+    fun testDeserializeActualApiResponseFormat() {
+        // 実際のAPIレスポンスで発生するエラーパターンの再現テスト
+        // hardMutedWords に正規表現パターン（文字列）が含まれるケース
+        val jsonString = """["/(@.+@.+\\\\..+){5,}/", ["keyword1", "keyword2"]]"""
+        val items = json.decodeFromString(listSerializer, jsonString)
+
+        assertEquals(2, items.size)
+
+        // 1番目: 正規表現（元のエラーの原因となった形式）
+        assertTrue(items[0] is MutedWordItem.RegexPattern)
+        assertEquals("/(@.+@.+\\\\..+){5,}/", (items[0] as MutedWordItem.RegexPattern).pattern)
+
+        // 2番目: キーワード配列
+        assertTrue(items[1] is MutedWordItem.Keywords)
+        assertEquals(listOf("keyword1", "keyword2"), (items[1] as MutedWordItem.Keywords).words)
+    }
+
+    @Test
+    fun testDeserializeSingleKeywordArray() {
+        // 単一キーワードの配列
+        val jsonString = """["single"]"""
+        val item = json.decodeFromString<MutedWordItem>(jsonString)
+
+        assertTrue(item is MutedWordItem.Keywords)
+        assertEquals(listOf("single"), (item as MutedWordItem.Keywords).words)
+    }
+}


### PR DESCRIPTION
## Summary
- `mutedWords` / `hardMutedWords` を正規表現パターン（文字列）とキーワード配列の混在形式に対応するように修正
- `MutedWordItem` sealed class と専用シリアライザを追加

## Background
Misskey の `mutedWords` / `hardMutedWords` は以下の2種類の形式を混在できます：
- 正規表現パターン: `"/pattern/"` 形式の文字列
- キーワード配列: `["word1", "word2"]` 形式のAND条件

従来の `Array<Array<String>>` 型では正規表現パターン（文字列）が来ると `JsonDecodingException: Expected JsonArray, but had JsonLiteral` エラーが発生していました。

## Changes
- `MutedWordItem.kt`: sealed class を新規作成（`RegexPattern` / `Keywords` サブクラス）
- `MutedWordItemSerializer.kt`: カスタムシリアライザを新規作成
- `MeDetailed.kt`: `mutedWords` / `hardMutedWords` の型を `List<MutedWordItem>` に変更
- `MutedWordItemSerializerTest.kt`: ユニットテストを追加

## Test plan
- [x] 正規表現パターンのデシリアライズが正しく動作することを確認
- [x] キーワード配列のデシリアライズが正しく動作することを確認
- [x] 混在形式のデシリアライズが正しく動作することを確認
- [x] シリアライズ→デシリアライズの往復テストがパスすることを確認



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced enhanced muted words functionality supporting both regex patterns and keyword-based filtering options.
  * Improved user profile data handling to properly serialize and deserialize muted word formats from the API for better content filtering capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->