### PR TITLE
Fix: ClipsListRequest の継承元を PagingTokenRequest に変更

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/clips/ClipsListRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/clips/ClipsListRequest.kt
@@ -1,9 +1,9 @@
 package work.socialhub.kmisskey.api.request.clips
 
 import kotlinx.serialization.Serializable
-import work.socialhub.kmisskey.api.model.TokenRequest
+import work.socialhub.kmisskey.api.request.protocol.PagingTokenRequest
 import kotlin.js.JsExport
 
 @JsExport
 @Serializable
-class ClipsListRequest : TokenRequest()
+class ClipsListRequest : PagingTokenRequest()


### PR DESCRIPTION
## Summary
- `ClipsListRequest` の継承元を `TokenRequest` から `PagingTokenRequest` に変更
- これにより `limit`, `sinceId`, `untilId` パラメータが使用可能に

## Background
Misskey の `clips/list` API は `limit` パラメータをサポートしており、デフォルト値は10件です。
しかし `ClipsListRequest` が `TokenRequest` を継承していたため、`limit` を指定できず、常に10件しか取得できませんでした。

ちなみにページネーション対応は https://github.com/misskey-dev/misskey/commit/1eabb21d69fc365970a03eabde20d54d05966f64 の 2025.8.0 版で行われており、`misskey.io` は現状未対応です。`misskey.noellabo.jp` で動作確認しました。

## Changes
- `ClipsListRequest.kt`: 継承元を `TokenRequest` から `PagingTokenRequest` に変更

## Test plan
- [ ] `ClipsListRequest` に `limit` を設定してビルドが通ることを確認
- [ ] clips/list API で limit を指定して期待通りの件数が取得できることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated clips list request implementation to support pagination handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->