### PR TITLE
Feature: users/search に認証必須のバリエーションを追加

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/UsersResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/UsersResource.kt
@@ -7,6 +7,7 @@ import work.socialhub.kmisskey.api.request.users.UsersRecommendationRequest
 import work.socialhub.kmisskey.api.request.users.UsersRelationRequest
 import work.socialhub.kmisskey.api.request.users.UsersSearchByUsernameAndHostRequest
 import work.socialhub.kmisskey.api.request.users.UsersSearchRequest
+import work.socialhub.kmisskey.api.request.users.UsersSearchWithAuthRequest
 import work.socialhub.kmisskey.api.request.users.UsersShowMultipleRequest
 import work.socialhub.kmisskey.api.request.users.UsersShowSingleRequest
 import work.socialhub.kmisskey.api.response.notes.UsersReactionsResponse
@@ -130,6 +131,19 @@ interface UsersResource {
     @JsExport.Ignore
     fun searchBlocking(
         request: UsersSearchRequest
+    ): Response<Array<UsersSearchResponse>>
+
+    /**
+     * ユーザーを検索します。（認証必須）
+     * https://misskey.io/api-doc#operation/users/search
+     */
+    suspend fun searchWithAuth(
+        request: UsersSearchWithAuthRequest
+    ): Response<Array<UsersSearchResponse>>
+
+    @JsExport.Ignore
+    fun searchWithAuthBlocking(
+        request: UsersSearchWithAuthRequest
     ): Response<Array<UsersSearchResponse>>
 
     /**

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/users/UsersSearchWithAuthRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/users/UsersSearchWithAuthRequest.kt
@@ -1,0 +1,17 @@
+package work.socialhub.kmisskey.api.request.users
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kmisskey.api.model.TokenRequest
+import kotlin.js.JsExport
+
+@JsExport
+@Serializable
+class UsersSearchWithAuthRequest : TokenRequest() {
+
+    var query: String? = null
+    var offset: Int? = null
+    var limit: Int? = null
+
+    var localOnly: Boolean? = null
+    var detail: Boolean? = null
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/internal/api/UsersResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/internal/api/UsersResourceImpl.kt
@@ -16,6 +16,7 @@ import work.socialhub.kmisskey.api.request.users.UsersRecommendationRequest
 import work.socialhub.kmisskey.api.request.users.UsersRelationRequest
 import work.socialhub.kmisskey.api.request.users.UsersSearchByUsernameAndHostRequest
 import work.socialhub.kmisskey.api.request.users.UsersSearchRequest
+import work.socialhub.kmisskey.api.request.users.UsersSearchWithAuthRequest
 import work.socialhub.kmisskey.api.request.users.UsersShowMultipleRequest
 import work.socialhub.kmisskey.api.request.users.UsersShowSingleRequest
 import work.socialhub.kmisskey.api.response.notes.UsersReactionsResponse
@@ -192,6 +193,26 @@ class UsersResourceImpl(
     ): Response<Array<UsersSearchResponse>> {
         return toBlocking {
             search(request)
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override suspend fun searchWithAuth(
+        request: UsersSearchWithAuthRequest
+    ): Response<Array<UsersSearchResponse>> {
+        return post(UsersSearch.path, request)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun searchWithAuthBlocking(
+        request: UsersSearchWithAuthRequest
+    ): Response<Array<UsersSearchResponse>> {
+        return toBlocking {
+            searchWithAuth(request)
         }
     }
 


### PR DESCRIPTION
## Summary
- `users/search` API に認証必須のバリエーション `searchWithAuth` / `searchWithAuthBlocking` を追加
- 一部のMisskeyサーバーでは `users/search` に認証が必要なため(`misskey.design`で確認)

## Background
Misskeyサーバーによっては `users/search` エンドポイントで認証が必要な場合があります。
従来の `search` メソッドは `postAny`（認証なし）を使用しているため、認証必須のサーバーでは使用できませんでした。
misskey.designでは500エラーが返ってきました。

## Changes
- `UsersSearchWithAuthRequest.kt`: 認証必須用の新規リクエストクラスを追加（`TokenRequest` を継承）
- `UsersResource.kt`: `searchWithAuth` / `searchWithAuthBlocking` を追加
- `UsersResourceImpl.kt`: `searchWithAuth` / `searchWithAuthBlocking` の実装を追加（`post` を使用）

## Usage
| メソッド | リクエストクラス | 内部処理 | 用途 |
|---------|----------------|---------|------|
| `search` | `UsersSearchRequest` | `postAny`（トークンなし） | 認証不要なサーバー向け |
| `searchWithAuth` | `UsersSearchWithAuthRequest` | `post`（トークンあり） | 認証必須なサーバー向け |

## Test plan
- [ ] `search` が従来通り認証なしで動作することを確認
- [ ] `searchWithAuth` が認証ありで動作することを確認
- [ ] 認証必須サーバーで `searchWithAuth` が正常に動作することを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated user search functionality with comprehensive filtering options. Users can now perform searches using their authentication credentials while customizing multiple parameters: search query text, pagination controls (offset and limit), filtering to display local-only results, and requesting detailed user profile information to refine their searches and improve overall user discovery experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->