### PR TITLE
Fix: bannerColor/avatarColor の rgb() 形式に対応

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/user/User.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/user/User.kt
@@ -9,6 +9,7 @@ import work.socialhub.kmisskey.entity.Instance
 import work.socialhub.kmisskey.entity.Role
 import work.socialhub.kmisskey.entity.UserPolicies
 import work.socialhub.kmisskey.util.BlurHashDecoder
+import work.socialhub.kmisskey.util.ColorDecoder
 import work.socialhub.kmisskey.util.json.UserSerializer
 import kotlin.js.JsExport
 
@@ -56,24 +57,33 @@ abstract class User {
      * The following are original items.
      * 以下、独自項目
      */
-    var avatarColor: Color? = null
-        get() {
-            if (field == null) {
-                val decoder = BlurHashDecoder.instance
-                val ary = decoder.decode(
-                    avatarBlurhash,
-                    1,
-                    1,
-                    1F,
-                    false
-                ) ?: return null
 
-                val color = Color()
-                color.r = ary[0][0][0]
-                color.g = ary[0][0][1]
-                color.b = ary[0][0][2]
-                return color
+    // サーバーから返される色文字列 (例: "rgb(169,122,93)", "#86b300")
+    var avatarColor: String? = null
+
+    // avatarColor を Color オブジェクトとして取得
+    // avatarColor が null の場合は avatarBlurhash から計算
+    val avatarColorObject: Color?
+        get() {
+            // avatarColor が設定されている場合はそれをデコード
+            avatarColor?.let {
+                return ColorDecoder.decode(it)
             }
-            return field
+
+            // avatarBlurhash からフォールバック計算
+            val decoder = BlurHashDecoder.instance
+            val ary = decoder.decode(
+                avatarBlurhash,
+                1,
+                1,
+                1F,
+                false
+            ) ?: return null
+
+            val color = Color()
+            color.r = ary[0][0][0]
+            color.g = ary[0][0][1]
+            color.b = ary[0][0][2]
+            return color
         }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/user/UserDetailedNotMe.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/user/UserDetailedNotMe.kt
@@ -6,6 +6,7 @@ import work.socialhub.kmisskey.entity.Field
 import work.socialhub.kmisskey.entity.Note
 import work.socialhub.kmisskey.entity.Page
 import work.socialhub.kmisskey.util.BlurHashDecoder
+import work.socialhub.kmisskey.util.ColorDecoder
 import kotlin.js.JsExport
 
 @JsExport
@@ -82,24 +83,33 @@ open class UserDetailedNotMe : UserLite() {
      * The following are original items.
      * 以下、独自項目
      */
-    var bannerColor: Color? = null
-        get() {
-            if (field == null) {
-                val decoder = BlurHashDecoder.instance
-                val ary = decoder.decode(
-                    bannerBlurhash,
-                    1,
-                    1,
-                    1F,
-                    false
-                ) ?: return null
 
-                val color = Color()
-                color.r = ary[0][0][0]
-                color.g = ary[0][0][1]
-                color.b = ary[0][0][2]
-                return color
+    // サーバーから返される色文字列 (例: "rgb(169,122,93)", "#86b300")
+    var bannerColor: String? = null
+
+    // bannerColor を Color オブジェクトとして取得
+    // bannerColor が null の場合は bannerBlurhash から計算
+    val bannerColorObject: Color?
+        get() {
+            // bannerColor が設定されている場合はそれをデコード
+            bannerColor?.let {
+                return ColorDecoder.decode(it)
             }
-            return field
+
+            // bannerBlurhash からフォールバック計算
+            val decoder = BlurHashDecoder.instance
+            val ary = decoder.decode(
+                bannerBlurhash,
+                1,
+                1,
+                1F,
+                false
+            ) ?: return null
+
+            val color = Color()
+            color.r = ary[0][0][0]
+            color.g = ary[0][0][1]
+            color.b = ary[0][0][2]
+            return color
         }
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/ColorDecoder.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/ColorDecoder.kt
@@ -27,9 +27,9 @@ object ColorDecoder {
             val rgb = color
                 .replace("rgb(", "")
                 .replace(")", "").split(",")
-            val r = rgb[0].toInt()
-            val g = rgb[1].toInt()
-            val b = rgb[2].toInt()
+            val r = rgb[0].trim().toInt()
+            val g = rgb[1].trim().toInt()
+            val b = rgb[2].trim().toInt()
             return Color().apply {
                 this.r = r
                 this.g = g
@@ -39,9 +39,9 @@ object ColorDecoder {
 
         // R,G,B
         val rgb = color.split(",")
-        val r = rgb[0].toInt()
-        val g = rgb[1].toInt()
-        val b = rgb[2].toInt()
+        val r = rgb[0].trim().toInt()
+        val g = rgb[1].trim().toInt()
+        val b = rgb[2].trim().toInt()
         return Color().apply {
             this.r = r
             this.g = g

--- a/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/ColorDecoderTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/ColorDecoderTest.kt
@@ -1,10 +1,27 @@
 package work.socialhub.kmisskey.unit
 
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import work.socialhub.kmisskey.entity.Color
+import work.socialhub.kmisskey.entity.user.UserDetailedNotMe
 import work.socialhub.kmisskey.util.ColorDecoder
 
+/**
+ * ColorDecoder のユニットテスト
+ * bannerColor は String として受け取り、ColorDecoder で Color オブジェクトに変換する
+ */
 class ColorDecoderTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    // ========================================
+    // ColorDecoder 単体テスト
+    // ========================================
 
     @Test
     fun decodeHexWithPrefix() {
@@ -22,5 +39,121 @@ class ColorDecoderTest {
         assertEquals(0x86, color.r)
         assertEquals(0xb3, color.g)
         assertEquals(0x00, color.b)
+    }
+
+    @Test
+    fun decodeRgbFormat() {
+        val color = ColorDecoder.decode("rgb(169,122,93)")
+
+        assertEquals(169, color.r)
+        assertEquals(122, color.g)
+        assertEquals(93, color.b)
+    }
+
+    @Test
+    fun decodeRgbFormatWithSpaces() {
+        val color = ColorDecoder.decode("rgb(169, 122, 93)")
+
+        assertEquals(169, color.r)
+        assertEquals(122, color.g)
+        assertEquals(93, color.b)
+    }
+
+    @Test
+    fun decodeCommaSeparated() {
+        val color = ColorDecoder.decode("169,122,93")
+
+        assertEquals(169, color.r)
+        assertEquals(122, color.g)
+        assertEquals(93, color.b)
+    }
+
+    // ========================================
+    // User の bannerColor テスト
+    // ========================================
+
+    @Test
+    fun testDeserializeUserWithBannerColorRgbString() {
+        // bannerColor が rgb文字列形式で返される場合のテスト
+        val jsonString = """
+        {
+          "id": "test123",
+          "name": "Test User",
+          "username": "testuser",
+          "host": null,
+          "avatarUrl": "https://example.com/avatar.jpg",
+          "isBot": false,
+          "isCat": false,
+          "createdAt": "2024-01-01T00:00:00.000Z",
+          "bannerColor": "rgb(169,122,93)"
+        }
+        """.trimIndent()
+
+        val user = json.decodeFromString<UserDetailedNotMe>(jsonString)
+
+        assertEquals("test123", user.id)
+        assertEquals("testuser", user.username)
+
+        // bannerColor は文字列として保持される
+        assertEquals("rgb(169,122,93)", user.bannerColor)
+
+        // bannerColorObject で Color オブジェクトを取得
+        assertNotNull(user.bannerColorObject)
+        assertEquals(169, user.bannerColorObject!!.r)
+        assertEquals(122, user.bannerColorObject!!.g)
+        assertEquals(93, user.bannerColorObject!!.b)
+    }
+
+    @Test
+    fun testDeserializeUserWithBannerColorHexString() {
+        // bannerColor が hex形式で返される場合のテスト
+        val jsonString = """
+        {
+          "id": "test123",
+          "name": "Test User",
+          "username": "testuser",
+          "host": null,
+          "avatarUrl": "https://example.com/avatar.jpg",
+          "isBot": false,
+          "isCat": false,
+          "createdAt": "2024-01-01T00:00:00.000Z",
+          "bannerColor": "#86b300"
+        }
+        """.trimIndent()
+
+        val user = json.decodeFromString<UserDetailedNotMe>(jsonString)
+
+        assertEquals("test123", user.id)
+        assertEquals("#86b300", user.bannerColor)
+
+        assertNotNull(user.bannerColorObject)
+        assertEquals(0x86, user.bannerColorObject!!.r)
+        assertEquals(0xb3, user.bannerColorObject!!.g)
+        assertEquals(0x00, user.bannerColorObject!!.b)
+    }
+
+    @Test
+    fun testDeserializeUserWithBannerColorNull() {
+        // bannerColor が null の場合
+        val jsonString = """
+        {
+          "id": "test123",
+          "name": "Test User",
+          "username": "testuser",
+          "host": null,
+          "avatarUrl": "https://example.com/avatar.jpg",
+          "isBot": false,
+          "isCat": false,
+          "createdAt": "2024-01-01T00:00:00.000Z",
+          "bannerColor": null
+        }
+        """.trimIndent()
+
+        val user = json.decodeFromString<UserDetailedNotMe>(jsonString)
+
+        assertEquals("test123", user.id)
+        assertNull(user.bannerColor)
+        // bannerBlurhash も null なので bannerColorObject も null
+        assertNull(user.bannerColorObject)
     }
 }


### PR DESCRIPTION
## Summary
- `bannerColor` / `avatarColor` が `"rgb(169,122,93)"` のような文字列形式で返される場合に対応
- `Role.color` と同様のパターン（String + colorObject）に統一

## Background
一部のMisskeyインスタンスでは `bannerColor` が `"rgb(169,122,93)"` のような文字列形式で返されることがあり、`JsonDecodingException: Expected JsonObject, but had JsonLiteral` エラーが発生していました。

## Changes
- `User.kt`: `avatarColor: Color?` → `avatarColor: String?` + `avatarColorObject: Color?`
- `UserDetailedNotMe.kt`: `bannerColor: Color?` → `bannerColor: String?` + `bannerColorObject: Color?`
- `ColorDecoder.kt`: rgb() 形式のスペース対応を追加（`trim()`）
- `ColorDecoderTest.kt`: テストケースを追加

## Migration
Color オブジェクトを取得する場合は、プロパティ名を変更してください：
- `user.avatarColor` → `user.avatarColorObject`
- `user.bannerColor` → `user.bannerColorObject`

## Test plan
- [x] rgb() 形式のデシリアライズが正しく動作することを確認
- [x] hex 形式のデシリアライズが正しく動作することを確認
- [x] null の場合のデシリアライズが正しく動作することを確認
- [x] 既存の ColorDecoder テストがパスすることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of color string parsing by handling whitespace in RGB color values.

* **Tests**
  * Expanded test coverage for color decoding and user profile color handling to ensure reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->