### PR TITLE
Set JVM target to 11 and add test secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.iml
 .idea
 .gradle
+.gradle-home
 .kotlin
 .envrc
 target/

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.compile.JavaCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
@@ -7,8 +9,11 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
 
     js(IR) {
         nodejs()
@@ -65,4 +70,8 @@ kotlin {
 
 tasks.named<Test>("jvmTest") {
     useJUnitPlatform()
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(11)
 }

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.compile.JavaCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
@@ -7,8 +9,11 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
 
     js(IR) {
         nodejs()
@@ -49,4 +54,8 @@ kotlin {
 
 tasks.named<Test>("jvmTest") {
     useJUnitPlatform()
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(11)
 }


### PR DESCRIPTION
Configure Kotlin JVM targets to Java 11 for core and stream modules by using kotlin.jvm { compilerOptions { jvmTarget.set(JvmTarget.JVM_11) } } and setting JavaCompile.options.release=11. Add required imports for JavaCompile and JvmTarget. Add .gradle-home to .gitignore. Update AbstractTest: provide fallback APP_SECRET and USER_TOKEN for local testing, add a runtime check in misskey() with a helpful message, and add secretsAvailable() helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for improved JVM 11 targeting across build scripts.
  * Enhanced Gradle build system configuration with updated toolchain settings.
  * Added Gradle cache directory to ignore patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->