### PR TITLE
Add support for short hex color format (#RGB) in ColorDecoder

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/ColorDecoder.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/util/ColorDecoder.kt
@@ -9,9 +9,15 @@ object ColorDecoder {
      */
     fun decode(color: String): Color {
 
-        // #RRGGBB または RRGGBB (6文字の16進数)
-        if (color.startsWith("#") || (color.length == 6 && color.all { it.isHexDigit() })) {
-            val hex = color.removePrefix("#")
+        // #RRGGBB, #RGB, RRGGBB, RGB (16進数)
+        if (color.startsWith("#") || (color.length == 6 && color.all { it.isHexDigit() }) || (color.length == 3 && color.all { it.isHexDigit() })) {
+            val short = color.removePrefix("#")
+            // 3文字の短縮形(#RGB)を6文字(#RRGGBB)に展開
+            val hex = if (short.length == 3) {
+                "${short[0]}${short[0]}${short[1]}${short[1]}${short[2]}${short[2]}"
+            } else {
+                short
+            }
             val r = hex.substring(0, 2).toInt(16)
             val g = hex.substring(2, 4).toInt(16)
             val b = hex.substring(4, 6).toInt(16)

--- a/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/ColorDecoderTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kmisskey/unit/ColorDecoderTest.kt
@@ -42,6 +42,34 @@ class ColorDecoderTest {
     }
 
     @Test
+    fun decodeShortHexWithPrefix() {
+        // #RGB → #RRGGBB に展開される
+        val color = ColorDecoder.decode("#fff")
+
+        assertEquals(0xff, color.r)
+        assertEquals(0xff, color.g)
+        assertEquals(0xff, color.b)
+    }
+
+    @Test
+    fun decodeShortHexWithPrefix2() {
+        val color = ColorDecoder.decode("#abc")
+
+        assertEquals(0xaa, color.r)
+        assertEquals(0xbb, color.g)
+        assertEquals(0xcc, color.b)
+    }
+
+    @Test
+    fun decodeShortHexWithoutPrefix() {
+        val color = ColorDecoder.decode("f80")
+
+        assertEquals(0xff, color.r)
+        assertEquals(0x88, color.g)
+        assertEquals(0x00, color.b)
+    }
+
+    @Test
     fun decodeRgbFormat() {
         val color = ColorDecoder.decode("rgb(169,122,93)")
 


### PR DESCRIPTION
## Summary
- `ColorDecoder` が `#RGB` 形式の3文字短縮hexカラーコードをサポートするように修正
- `#RGB` を `#RRGGBB` に展開してからパースする処理を追加

## Background
一部のMisskeyインスタンスでは `Instance.themeColor` が `#fff` のような3文字短縮hex形式で返されることがあり、`StringIndexOutOfBoundsException` が発生していました。

## Changes
- `ColorDecoder.kt`: 3文字短縮hex(`#RGB`, `RGB`)を6文字(`RRGGBB`)に展開する処理を追加
- `ColorDecoderTest.kt`: 短縮hexのテストケースを追加（`#fff`, `#abc`, `f80`）

## Test plan
- [x] `#RGB` 形式のカラーコードが正しくパースされることを確認
- [x] `RGB` 形式（プレフィックスなし）のカラーコードが正しくパースされることを確認
- [x] 既存の `#RRGGBB`, `RRGGBB`, `rgb()`, カンマ区切りのテストがパスすることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Color decoder now supports 3-digit hex color codes (e.g., #abc), which automatically expand to the standard 6-digit format for consistent rendering.

* **Tests**
  * Added test coverage for short hex color format and banner color parsing across multiple color formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->