### PR TITLE
Replace deprecated -Xenable-suspend-function-exporting with -XXLangua…

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
     linuxX64()
 
     compilerOptions {
-        freeCompilerArgs.add("-Xenable-suspend-function-exporting")
+        freeCompilerArgs.add("-XXLanguage:+JsAllowExportingSuspendFunctions")
     }
 
     sourceSets {


### PR DESCRIPTION
…ge:+JsAllowExportingSuspendFunctions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve compiler compatibility.

**Note:** This is a technical maintenance update with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->