### PR TITLE
Feature: Add maxFileSizeMb to Policies

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/Policies.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/entity/Policies.kt
@@ -11,4 +11,9 @@ class Policies {
     var ltlAvailable: Boolean? = null
     var canPublicNote: Boolean? = null
     var canInvite: Boolean? = null
+
+    /**
+     * Maximum upload size per file in MiB.
+     */
+    var maxFileSizeMb: Int? = null
 }


### PR DESCRIPTION
## Summary
- Add `maxFileSizeMb: Int?` property to the `Policies` class
- Maps to `policies.maxFileSizeMb` in the `/api/meta` response (Misskey 13.x+)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration property to track and specify the maximum allowed file upload size in megabytes, enabling better control over file upload constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uakihir0/kmisskey/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->