### PR TITLE
fix: allow http:// protocol in URL expression

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/MisskeyFactory.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/MisskeyFactory.kt
@@ -57,8 +57,8 @@ object MisskeyFactory {
     ): String {
         var result = url
 
-        // ホスト名だけで指定してきた場合
-        if (!result.startsWith("https://")) {
+        // プロトコル指定がない場合のみ https:// を付与
+        if (!result.startsWith("https://") && !result.startsWith("http://")) {
             result = "https://$result"
         }
         // API ディレクトリが抜けていた場合


### PR DESCRIPTION
absorbUrlExpression was unconditionally prepending https:// when the URL didn't start with https://, breaking http:// proxy URLs. Now only prepends https:// when neither https:// nor http:// is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed URL handling to properly recognize both HTTP and HTTPS protocols. URLs without an explicit protocol will now correctly default to HTTPS.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uakihir0/kmisskey/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->