### PR TITLE
Allow overriding stream host in MisskeyStream

### DIFF
--- a/stream/src/commonMain/kotlin/work/socialhub/kmisskey/stream/MisskeyStream.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kmisskey/stream/MisskeyStream.kt
@@ -6,13 +6,14 @@ import work.socialhub.kmisskey.stream.callback.NoteCallback
 import work.socialhub.kmisskey.stream.callback.TimelineCallback
 
 class MisskeyStream(
-    misskey: Misskey
+    misskey: Misskey,
+    streamHost: String? = null,
 ) {
     val url: String
     val client: StreamClient
 
     init {
-        val host = misskey.host
+        val host = streamHost ?: misskey.host
         val i = checkNotNull(misskey.i)
         url = "wss://$host/streaming?i=$i"
         client = StreamClient(url)


### PR DESCRIPTION
Add an optional streamHost parameter (default null) to MisskeyStream and use it when building the websocket URL. When provided, streamHost overrides misskey.host; otherwise the original host is used, preserving existing behavior.