### PR TITLE
Strip protocol prefix from stream host to prevent malformed WebSocket…

### DIFF
--- a/stream/src/commonMain/kotlin/work/socialhub/kmisskey/stream/MisskeyStream.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kmisskey/stream/MisskeyStream.kt
@@ -13,7 +13,10 @@ class MisskeyStream(
     val client: StreamClient
 
     init {
-        val host = streamHost ?: misskey.host
+        val host = (streamHost ?: misskey.host)
+            .removePrefix("https://")
+            .removePrefix("http://")
+            .trimEnd('/')
         val i = checkNotNull(misskey.i)
         url = "wss://$host/streaming?i=$i"
         client = StreamClient(url)


### PR DESCRIPTION
… URL

When streamHost contains a full URL like "https://misskey.io", the WebSocket URL was constructed as "wss://https://misskey.io/streaming" which is invalid. Now removes http(s):// prefix and trailing slash before building the wss:// URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming connection handling to properly normalize host URLs by removing protocol prefixes and trailing slashes for reliable connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->