### PR TITLE
feat: support protocol prefix in MisskeyStream streamHost

### DIFF
--- a/stream/src/commonMain/kotlin/work/socialhub/kmisskey/stream/MisskeyStream.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kmisskey/stream/MisskeyStream.kt
@@ -13,12 +13,24 @@ class MisskeyStream(
     val client: StreamClient
 
     init {
-        val host = (streamHost ?: misskey.host)
-            .removePrefix("https://")
-            .removePrefix("http://")
-            .trimEnd('/')
+        val raw = streamHost ?: misskey.host
+        val protocol: String
+        val host: String
+        if (raw.contains("://")) {
+            val parts = raw.split("://", limit = 2)
+            protocol = when (parts[0]) {
+                "ws", "wss" -> parts[0]
+                "http" -> "ws"
+                "https" -> "wss"
+                else -> "wss"
+            }
+            host = parts[1].trimEnd('/')
+        } else {
+            protocol = "wss"
+            host = raw.trimEnd('/')
+        }
         val i = checkNotNull(misskey.i)
-        url = "wss://$host/streaming?i=$i"
+        url = "$protocol://$host/streaming?i=$i"
         client = StreamClient(url)
     }
 


### PR DESCRIPTION
Handle wss://, ws://, https://, http:// prefixes in streamHost. Map https to wss and http to ws for WebSocket connection. When no protocol is specified, default to wss://.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced streaming connection URL handling to better support different host configurations and protocol schemes, improving reliability and compatibility with various server setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->