### PR TITLE
Feature: Drive API (files / folders / files/show) 対応

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/Misskey.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/Misskey.kt
@@ -9,6 +9,7 @@ import work.socialhub.kmisskey.api.AuthResource
 import work.socialhub.kmisskey.api.BlocksResource
 import work.socialhub.kmisskey.api.ChannelsResource
 import work.socialhub.kmisskey.api.ClipsResource
+import work.socialhub.kmisskey.api.DriveResource
 import work.socialhub.kmisskey.api.FavoritesResource
 import work.socialhub.kmisskey.api.FederationResource
 import work.socialhub.kmisskey.api.FilesResource
@@ -52,6 +53,7 @@ interface Misskey {
     fun polls(): PollsResource
     fun messages(): MessagesResource
     fun files(): FilesResource
+    fun drive(): DriveResource
     fun hashtags(): HashtagsResource
     fun other(): OtherResource
     fun webhook(): WebhooksResource

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/MisskeyAPI.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/MisskeyAPI.kt
@@ -208,6 +208,9 @@ enum class MisskeyAPI(
     // ------------------------------------------ //
 
     FilesCreate("drive/files/create"),
+    DriveFiles("drive/files"),
+    DriveFilesShow("drive/files/show"),
+    DriveFolders("drive/folders"),
 
     // ------------------------------------------ //
     // Hashtags

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/DriveResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/DriveResource.kt
@@ -1,0 +1,55 @@
+package work.socialhub.kmisskey.api
+
+import work.socialhub.kmisskey.api.request.drive.DriveFilesRequest
+import work.socialhub.kmisskey.api.request.drive.DriveFilesShowRequest
+import work.socialhub.kmisskey.api.request.drive.DriveFoldersRequest
+import work.socialhub.kmisskey.entity.File
+import work.socialhub.kmisskey.entity.Folder
+import work.socialhub.kmisskey.entity.share.Response
+import kotlin.js.JsExport
+
+@JsExport
+interface DriveResource {
+
+    /**
+     * ドライブのファイル一覧を取得します。
+     *
+     * https://misskey.io/api-doc#tag/drive/POST/drive/files
+     */
+    suspend fun files(
+        request: DriveFilesRequest
+    ): Response<Array<File>>
+
+    @JsExport.Ignore
+    fun filesBlocking(
+        request: DriveFilesRequest
+    ): Response<Array<File>>
+
+    /**
+     * ドライブのフォルダ一覧を取得します。
+     *
+     * https://misskey.io/api-doc#tag/drive/operation/drive/folders
+     */
+    suspend fun folders(
+        request: DriveFoldersRequest
+    ): Response<Array<Folder>>
+
+    @JsExport.Ignore
+    fun foldersBlocking(
+        request: DriveFoldersRequest
+    ): Response<Array<Folder>>
+
+    /**
+     * ドライブのファイル情報を取得します。
+     *
+     * https://misskey.io/api-doc#tag/drive/operation/drive/files/show
+     */
+    suspend fun showFile(
+        request: DriveFilesShowRequest
+    ): Response<File>
+
+    @JsExport.Ignore
+    fun showFileBlocking(
+        request: DriveFilesShowRequest
+    ): Response<File>
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/drive/DriveFilesRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/drive/DriveFilesRequest.kt
@@ -14,4 +14,8 @@ class DriveFilesRequest : PagingTokenRequest() {
     // MIME タイプによる絞り込み。
     // "image/jpeg" のような完全一致のほか、"image/*" 形式で前方一致 (image/ で始まるもの) も指定可能。
     var type: String? = null
+
+    // ソート順。
+    // "+createdAt", "-createdAt", "+name", "-name", "+size", "-size"
+    var sort: String? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/drive/DriveFilesRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/drive/DriveFilesRequest.kt
@@ -1,0 +1,17 @@
+package work.socialhub.kmisskey.api.request.drive
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kmisskey.api.request.protocol.PagingTokenRequest
+import kotlin.js.JsExport
+
+@JsExport
+@Serializable
+class DriveFilesRequest : PagingTokenRequest() {
+
+    // 取得対象フォルダID (null の場合はルートフォルダ)
+    var folderId: String? = null
+
+    // MIME タイプによる絞り込み。
+    // "image/jpeg" のような完全一致のほか、"image/*" 形式で前方一致 (image/ で始まるもの) も指定可能。
+    var type: String? = null
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/drive/DriveFilesShowRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/drive/DriveFilesShowRequest.kt
@@ -1,0 +1,16 @@
+package work.socialhub.kmisskey.api.request.drive
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kmisskey.api.model.TokenRequest
+import kotlin.js.JsExport
+
+@JsExport
+@Serializable
+class DriveFilesShowRequest : TokenRequest() {
+
+    // 取得対象のファイルID
+    var fileId: String? = null
+
+    // ファイルID の代わりに URL で指定する場合
+    var url: String? = null
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/drive/DriveFoldersRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/api/request/drive/DriveFoldersRequest.kt
@@ -1,0 +1,13 @@
+package work.socialhub.kmisskey.api.request.drive
+
+import kotlinx.serialization.Serializable
+import work.socialhub.kmisskey.api.request.protocol.PagingTokenRequest
+import kotlin.js.JsExport
+
+@JsExport
+@Serializable
+class DriveFoldersRequest : PagingTokenRequest() {
+
+    // 取得対象の親フォルダID (null の場合はルートフォルダ)
+    var folderId: String? = null
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/internal/MisskeyImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/internal/MisskeyImpl.kt
@@ -10,6 +10,7 @@ import work.socialhub.kmisskey.api.AuthResource
 import work.socialhub.kmisskey.api.BlocksResource
 import work.socialhub.kmisskey.api.ChannelsResource
 import work.socialhub.kmisskey.api.ClipsResource
+import work.socialhub.kmisskey.api.DriveResource
 import work.socialhub.kmisskey.api.FavoritesResource
 import work.socialhub.kmisskey.api.FederationResource
 import work.socialhub.kmisskey.api.FilesResource
@@ -35,6 +36,7 @@ import work.socialhub.kmisskey.internal.api.AuthResourceImpl
 import work.socialhub.kmisskey.internal.api.BlocksResourceImpl
 import work.socialhub.kmisskey.internal.api.ChannelsResourceImpl
 import work.socialhub.kmisskey.internal.api.ClipsResourceImpl
+import work.socialhub.kmisskey.internal.api.DriveResourceImpl
 import work.socialhub.kmisskey.internal.api.FavoritesResourceImpl
 import work.socialhub.kmisskey.internal.api.FederationResourceImpl
 import work.socialhub.kmisskey.internal.api.FilesResourceImpl
@@ -82,6 +84,7 @@ class MisskeyImpl(
     private val polls: PollsResource = PollsResourceImpl(uri, i)
     private val messages: MessagesResource = MessagesResourceImpl(uri, i)
     private val files: FilesResource = FilesResourceImpl(uri, i)
+    private val drive: DriveResource = DriveResourceImpl(uri, i)
     private val hashtags: HashtagsResource = HashtagsResourceImpl(uri, i)
     private val webhooks: WebhooksResource = WebhooksResourceImpl(uri, i)
     private val galleries: GalleriesResource = GalleriesResourceImpl(uri, i)
@@ -109,6 +112,7 @@ class MisskeyImpl(
     override fun polls() = polls
     override fun messages() = messages
     override fun files() = files
+    override fun drive() = drive
     override fun hashtags() = hashtags
     override fun other() = other
     override fun webhook() = webhooks

--- a/core/src/commonMain/kotlin/work/socialhub/kmisskey/internal/api/DriveResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmisskey/internal/api/DriveResourceImpl.kt
@@ -1,0 +1,80 @@
+package work.socialhub.kmisskey.internal.api
+
+import work.socialhub.kmisskey.MisskeyAPI.DriveFiles
+import work.socialhub.kmisskey.MisskeyAPI.DriveFilesShow
+import work.socialhub.kmisskey.MisskeyAPI.DriveFolders
+import work.socialhub.kmisskey.api.DriveResource
+import work.socialhub.kmisskey.api.request.drive.DriveFilesRequest
+import work.socialhub.kmisskey.api.request.drive.DriveFilesShowRequest
+import work.socialhub.kmisskey.api.request.drive.DriveFoldersRequest
+import work.socialhub.kmisskey.entity.File
+import work.socialhub.kmisskey.entity.Folder
+import work.socialhub.kmisskey.entity.share.Response
+import work.socialhub.kmisskey.util.toBlocking
+
+class DriveResourceImpl(
+    uri: String,
+    i: String
+) : AbstractResourceImpl(uri, i),
+    DriveResource {
+
+    /**
+     * {@inheritDoc}
+     */
+    override suspend fun files(
+        request: DriveFilesRequest
+    ): Response<Array<File>> {
+        return post(DriveFiles.path, request)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun filesBlocking(
+        request: DriveFilesRequest
+    ): Response<Array<File>> {
+        return toBlocking {
+            files(request)
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override suspend fun folders(
+        request: DriveFoldersRequest
+    ): Response<Array<Folder>> {
+        return post(DriveFolders.path, request)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun foldersBlocking(
+        request: DriveFoldersRequest
+    ): Response<Array<Folder>> {
+        return toBlocking {
+            folders(request)
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override suspend fun showFile(
+        request: DriveFilesShowRequest
+    ): Response<File> {
+        return post(DriveFilesShow.path, request)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun showFileBlocking(
+        request: DriveFilesShowRequest
+    ): Response<File> {
+        return toBlocking {
+            showFile(request)
+        }
+    }
+}


### PR DESCRIPTION
(いつも通りZonePaneで必要になったAPIの追加です)

## Summary
- ドライブ操作用の `DriveResource` を新規追加
- `drive/files`（ファイル一覧）、`drive/folders`（フォルダ一覧）、`drive/files/show`（ファイル情報取得）の3エンドポイントに対応

## Background
従来は `drive/files/create`（アップロード）のみ対応しており、ドライブ内のファイル・フォルダの一覧取得や個別ファイル情報の取得ができませんでした。
クライアント側でドライブの内容をブラウズする用途に対応するため、これらの参照系エンドポイントを追加します。

## Changes
- `DriveResource.kt` / `DriveResourceImpl.kt`: ドライブ参照系リソースを新規追加（suspend + Blocking の両方）
- `DriveFilesRequest.kt`: `drive/files` 用リクエスト（`folderId`、`type`、`PagingTokenRequest` 継承で `limit`/`sinceId`/`untilId` 対応）
- `DriveFoldersRequest.kt`: `drive/folders` 用リクエスト（`folderId`、`PagingTokenRequest` 継承）
- `DriveFilesShowRequest.kt`: `drive/files/show` 用リクエスト（`fileId` または `url` で指定）
- `MisskeyAPI.kt`: `DriveFiles` / `DriveFilesShow` / `DriveFolders` のパスを追加
- `Misskey.kt` / `MisskeyImpl.kt`: `drive()` アクセサを登録
- レスポンスは既存の `File` / `Folder` entity を再利用

## Test plan
- [ ] `drive/files` でファイル一覧が取得できることを確認
- [ ] `folderId` 指定時に対象フォルダ配下のファイルが取得できることを確認
- [ ] `drive/folders` でフォルダ一覧が取得できることを確認
- [ ] `drive/files/show` で `fileId` 指定によりファイル情報が取得できることを確認
- [ ] `limit`/`sinceId`/`untilId` によるページングが動作することを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Drive support: list files, browse folders, and view file details.
  * File listing supports optional folder selection, MIME-type filtering, and sort order.
  * Both asynchronous and synchronous access patterns are exposed for Drive operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->