### PR TITLE
Fix: remove unused kmpcommon dependency from stream module

### DIFF
--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -38,7 +38,6 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":core"))
             implementation(libs.ktor.core)
-            implementation(libs.kmpcommon)
             implementation(libs.khttpclient)
             implementation(libs.coroutines.core)
             implementation(libs.serialization.json)


### PR DESCRIPTION
## Summary
- Remove the unused `libs.kmpcommon` dependency from `stream/build.gradle.kts`

## Background
The `stream` module declares `implementation(libs.kmpcommon)` in its `commonMain`
dependencies, but `kmpcommon` is not referenced anywhere under `stream/src`.
This unused dependency unnecessarily adds to the dependency graph of consumers
of the `stream` module.

kmpcommon にはいわゆる古いdatetimeへの依存が含まれており、kmpcommon 自体が未使用ではありますが(拙作アプリの) iOS ビルドが通らない原因になっていました。


## Changes
- `stream/build.gradle.kts`: remove `implementation(libs.kmpcommon)` from `commonMain.dependencies`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies to improve stability and performance of the streaming module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->