### PR TITLE
remove debug println from StreamClient

### DIFF
--- a/stream/src/commonMain/kotlin/work/socialhub/kmisskey/stream/StreamClient.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kmisskey/stream/StreamClient.kt
@@ -96,7 +96,6 @@ class StreamClient(
         }
 
         val text = Internal.toJson(request)
-        println(text)
         client.sendText(text)
     }
 


### PR DESCRIPTION
The subscribe method was printing raw JSON to stdout on every WebSocket message send, polluting browser consoles in downstream apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug logging output from WebSocket communication to reduce log clutter and improve system output cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->